### PR TITLE
fix: fix trigger events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,12 @@
 name: CI
 
 on:
-  pull_request:
+  workflow_run:
+    workflows:
+      - reviewdog
+    types:
+      - completed
+  workflow_dispatch: {}
 
 jobs:
   test:
@@ -9,6 +14,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: test
         run: echo "todo"

--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -1,15 +1,12 @@
 name: Create Pull Request
 
 on:
-  push:
-    branches-ignore:
-      - "main"
-      - "master"
+  create: {}
 
 jobs:
   automated-pr:
     runs-on: ubuntu-18.04
-    if: ${{ github.event.created }}
+    if: ${{ github.event.ref_type == 'branch' }}
     steps:
       - name: check out
         uses: actions/checkout@v2
@@ -37,37 +34,29 @@ jobs:
         id: create_pr
         uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const query = process.env.PR_QUERY
+
+            const badge = `
+
+            ---
+            [![actions/github-script](https://img.shields.io/badge/generated%20by-GitHub%20Sctipt%20v3.1.0-blue?logoColor=b3e5fc&logo=github-actions)](https://github.com/marketplace/actions/github-script)
+            `
+
             const variables = {
               repoId: process.env.PR_REPOID,
               base: process.env.PR_BASE,
               head: process.env.PR_HEAD,
               title: process.env.PR_TITLE,
-              body: process.env.PR_BODY,
+              body: process.env.PR_BODY + badge,
             }
 
             return await github.graphql(query, variables)
         env:
           PR_QUERY: ${{ env.GQL_QUERY }}
           PR_REPOID: ${{ github.event.repository.node_id }}
-          PR_BASE: main
+          PR_BASE: ${{ github.event.repository.default_branch }}
           PR_HEAD: ${{ env.BRANCH }}
           PR_TITLE: "WIP: created automatically"
           PR_BODY: ${{ env.TEMPLATE }}
-
-      - name: post comment
-        uses: peter-evans/create-or-update-comment@5221bf4aa615e5c6e95bb142f9673a9c791be2cd
-        with:
-          issue-number: ${{ fromJson(steps.create_pr.outputs.result).createPullRequest.pullRequest.number }}
-          body: |
-            This pull request was generated automatically (by [actions/github-script][link-1]).
-            Please modify the title and body.
-
-            Thanks!
-
-            [![create-or-update-comment](https://img.shields.io/badge/used-Create%20or%20Update%20Comment-blue?logoColor=b3e5fc&logo=github-actions)][link-2]
-
-            [link-1]: https://github.com/actions/github-script
-            [link-2]: https://github.com/peter-evans/create-or-update-comment

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,9 +1,15 @@
 name: reviewdog
 
 on:
-  pull_request:
+  pull_request: {}
+  workflow_run:
+    workflows:
+      - Create Pull Request
+    types:
+      - completed
 
 env:
+  REF_SHA: ${{ github.event.workflow_run.head_sha }}
   DOG_CONFIG: .github/.reviewdog.yml
 
 jobs:
@@ -13,6 +19,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ env.REF_SHA }}
 
       - name: yamllint v1.2.0
         # https://github.com/reviewdog/action-yamllint
@@ -28,6 +36,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ env.REF_SHA }}
 
       - name: setup standard
         run: npm install standard


### PR DESCRIPTION
## Proposed Changes - 変更点の要約

- `create-pr` ワークフロー
  トリガーを `create` イベントに変更。
  投稿コメントをメッセージに統合。
- `reviewdog` ワークフロー
  自動プルリクエスト作成後に実行されるようトリガーに `workflow_run` イベントを追加。
- テスト用ワークフロー
  `reviewdog` 後に実行されるようにトリガーを `workflow_run` イベントに変更。
（手動確認用に `workflow_dispatch` イベントも追加）

Fix #24

### Type of changes - 変更の種類

Please check the type of change your PR.
And write the type to as a prefix to the title of your PR ([Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)).

- [x] `fix`: A bug fix
- [ ] `feat`: A new feature
- [ ] appends `!` after the type or a commit has `BREAKING CHANGE:` in footer : Breaking change (feature or bug fix)
- [ ] `chore`: Build tool changes
- [ ] `docs`: Documentation only changes

---
[![actions/github-script](https://img.shields.io/badge/generated%20by-GitHub%20Sctipt%20v3.1.0-blue?logoColor=b3e5fc&logo=github-actions)](https://github.com/marketplace/actions/github-script)
