### PR TITLE
fix: revert about create pr

### DIFF
--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -11,8 +11,19 @@ jobs:
       - name: check out
         uses: actions/checkout@v2
 
-      - name: current branch
-        run: echo "BRANCH=`git name-rev --name-only HEAD`" >> $GITHUB_ENV
+      - name: get git info
+        id: git-info
+        run: |
+          echo "::set-output name=branch::`git name-rev --name-only HEAD`"
+          echo "::set-output name=message::`git show --format=%s`"
+
+      - name: read graphql file
+        id: gql
+        run: |
+          exec 1>> $GITHUB_ENV
+          echo 'GQL_QUERY<<EOF'
+          cat .github/create-pr.gql
+          echo 'EOF'
 
       - name: read template of pull request
         id: template
@@ -23,16 +34,32 @@ jobs:
           echo 'EOF'
 
       - name: create pull request
-        run: |
-          echo $GITHUB_TOKEN | gh auth login --with-token
+        id: create_pr
+        uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7
+        with:
+          github-token: ${{ secrets.PERSONAL_TOKEN }}
+          script: |
+            const query = process.env.PR_QUERY
 
-          COMMIT_SUBJECT=`git show --format=%s`
+            const badge = `
 
-          gh pr create --draft \
-            --base $PR_BASE \
-            --title "WIP: $COMMIT_SUBJECT" \
-            --body $PR_BODY
+            ---
+            [![actions/github-script](https://img.shields.io/badge/generated%20by-GitHub%20Sctipt%20v3.1.0-blue?logoColor=b3e5fc&logo=github-actions)](https://github.com/marketplace/actions/github-script)
+            `
+
+            const variables = {
+              repoId: process.env.PR_REPOID,
+              base: process.env.PR_BASE,
+              head: process.env.PR_HEAD,
+              title: process.env.PR_TITLE_PREFIX + ': ' + '${{ steps.git-info.outputs.message }}',
+              body: process.env.PR_BODY + badge,
+            }
+
+            return await github.graphql(query, variables)
         env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+          PR_QUERY: ${{ env.GQL_QUERY }}
+          PR_REPOID: ${{ github.event.repository.node_id }}
           PR_BASE: ${{ github.event.repository.default_branch }}
+          PR_HEAD: ${{ steps.git-info.outputs.branch }}
+          PR_TITLE_PREFIX: "WIP"
           PR_BODY: ${{ env.TEMPLATE }}


### PR DESCRIPTION
## Proposed Changes - 変更点の要約

プルリクエストの自動生成において、 `gh` コマンドでは必要となる _Personal Access Token_ のスコープが広いので、
`actions/github-script` を使う方法に戻した。

### Type of changes - 変更の種類

Please check the type of change your PR.
And write the type to as a prefix to the title of your PR ([Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)).

- [x] `fix`: A bug fix
- [ ] `feat`: A new feature
- [ ] appends `!` after the type or a commit has `BREAKING CHANGE:` in footer : Breaking change (feature or bug fix)
- [ ] `chore`: Build tool changes
- [ ] `docs`: Documentation only changes

---
[![actions/github-script](https://img.shields.io/badge/generated%20by-GitHub%20Sctipt%20v3.1.0-blue?logoColor=b3e5fc&logo=github-actions)](https://github.com/marketplace/actions/github-script)
