### PR TITLE
fix: change events to status of semantic-pull-request

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -5,23 +5,18 @@ on:
     types:
       - labeled
       - unlabeled
-      - synchronize
-      - opened
       - ready_for_review
-      - reopened
       - unlocked
   pull_request_review:
     types:
       - submitted
-  check_suite:
-    types:
-      - completed
   status: {}
 
 jobs:
   automerge:
     runs-on: ubuntu-20.04
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'automerge') || !contains(github.event_name, 'pull_request') }}
+    name: auto merge
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'automerge') || contains(github.event_name, 'pull_request_review') || github.event.state == 'success' }}
     steps:
       - name: automerge
         uses: "pascalgn/automerge-action@c9bd182"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,14 +1,13 @@
 name: Auto-labeled-on-PR
 
 on:
-  pull_request:
-    types:
-      - "opened"
-      - "edited"
+  status: {}
 
 jobs:
   auto-labeled:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
+    name: auto labeled
+    if: ${{ github.event.state == 'success' }}
     steps:
       - name: labeled
         uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7


### PR DESCRIPTION
## Proposed Changes - 変更点の要約

並列起動の緩和のため、`Semantic Pull Request` による `status` イベントをトリガーにするよう変更した。

Fix #29

### Type of changes - 変更の種類

Please check the type of change your PR.
And write the type to as a prefix to the title of your PR ([Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)).

- [x] `fix`: A bug fix
- [ ] `feat`: A new feature
- [ ] appends `!` after the type or a commit has `BREAKING CHANGE:` in footer : Breaking change (feature or bug fix)
- [ ] `chore`: Build tool changes
- [ ] `docs`: Documentation only changes

---
[![actions/github-script](https://img.shields.io/badge/generated%20by-GitHub%20Sctipt%20v3.1.0-blue?logoColor=b3e5fc&logo=github-actions)](https://github.com/marketplace/actions/github-script)
