### PR TITLE
fix: fixed the behavior about labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -36,9 +36,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const config = [
-              { title: /^(fix|docs|style|refactor|perf|chore)[^:]*:/, labels: ['patch'] },
-              { title: /^feat[^:]*:/, labels: ['minor'] },
-              { title: /^([^:]+!|BREAKING CHANGE):/, labels: ['major'] },
+              { title: /^feat[^:]*:/, labels: ['enhancement'] },
+              { title: /^fix[^:]*:/, labels: ['fix'] },
+              { title: /^docs[^:]*:/, labels: ['documentation'] },
+              { title: /^chore[^:]*:/, labels: ['chore'] },
+              { title: /^(style|refactor|perf|test|build|ci|revert)[^:]*:/, labels: ['patch'] },
+              { title: /^([^:]+!|BREAKING CHANGE):/, labels: ['BREAKING CHANGE'] },
             ]
 
             const labels = config

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,18 +1,39 @@
 name: Auto-labeled-on-PR
 
 on:
-  status: {}
+  pull_request:
+    types:
+      - opened
+      - edited
 
 jobs:
   auto-labeled:
     runs-on: ubuntu-20.04
     name: auto labeled
-    if: ${{ github.event.state == 'success' }}
+    # reference conventional commit types
+    # https://github.com/commitizen/conventional-commit-types/blob/master/index.json
+    if: |
+      ${{
+        github.event.pull_request.state == 'open' &&
+        (
+          startWith(github.event.pull_request.title, 'feat') ||
+          startWith(github.event.pull_request.title, 'fix') ||
+          startWith(github.event.pull_request.title, 'chore') ||
+          startWith(github.event.pull_request.title, 'docs') ||
+          startWith(github.event.pull_request.title, 'style') ||
+          startWith(github.event.pull_request.title, 'refactor') ||
+          startWith(github.event.pull_request.title, 'pref') ||
+          startWith(github.event.pull_request.title, 'test') ||
+          startWith(github.event.pull_request.title, 'build') ||
+          startWith(github.event.pull_request.title, 'ci') ||
+          startWith(github.event.pull_request.title, 'revert')
+        )
+      }}
     steps:
       - name: labeled
         uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const config = [
               { title: /^(fix|docs|style|refactor|perf|chore)[^:]*:/, labels: ['patch'] },

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -16,17 +16,17 @@ jobs:
       ${{
         github.event.pull_request.state == 'open' &&
         (
-          startWith(github.event.pull_request.title, 'feat') ||
-          startWith(github.event.pull_request.title, 'fix') ||
-          startWith(github.event.pull_request.title, 'chore') ||
-          startWith(github.event.pull_request.title, 'docs') ||
-          startWith(github.event.pull_request.title, 'style') ||
-          startWith(github.event.pull_request.title, 'refactor') ||
-          startWith(github.event.pull_request.title, 'pref') ||
-          startWith(github.event.pull_request.title, 'test') ||
-          startWith(github.event.pull_request.title, 'build') ||
-          startWith(github.event.pull_request.title, 'ci') ||
-          startWith(github.event.pull_request.title, 'revert')
+          startsWith(github.event.pull_request.title, 'feat') ||
+          startsWith(github.event.pull_request.title, 'fix') ||
+          startsWith(github.event.pull_request.title, 'chore') ||
+          startsWith(github.event.pull_request.title, 'docs') ||
+          startsWith(github.event.pull_request.title, 'style') ||
+          startsWith(github.event.pull_request.title, 'refactor') ||
+          startsWith(github.event.pull_request.title, 'pref') ||
+          startsWith(github.event.pull_request.title, 'test') ||
+          startsWith(github.event.pull_request.title, 'build') ||
+          startsWith(github.event.pull_request.title, 'ci') ||
+          startsWith(github.event.pull_request.title, 'revert')
         )
       }}
     steps:


### PR DESCRIPTION
## Proposed Changes - 変更点の要約

期待通りの動作にならなかったのでトリガーするイベントを `pull_request` に戻した。
また自動リリース設定にあわせてラベル分類を追加した。

Fix #48

### Type of changes - 変更の種類

Please check the type of change your PR.
And write the type to as a prefix to the title of your PR ([Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)).

- [x] `fix`: A bug fix
- [ ] `feat`: A new feature
- [ ] appends `!` after the type or a commit has `BREAKING CHANGE:` in footer : Breaking change (feature or bug fix)
- [ ] `chore`: Build tool changes
- [ ] `docs`: Documentation only changes

---
[![actions/github-script](https://img.shields.io/badge/generated%20by-GitHub%20Sctipt%20v3.1.0-blue?logoColor=b3e5fc&logo=github-actions)](https://github.com/marketplace/actions/github-script)
