### PR TITLE
fix: change to the merged event

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,18 @@
 name: draft next release
 
 on:
-  push:
+  pull_request:
     branches:
+      - master
       - main
+    types:
+      - closed
 
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     name: release drafter v5.12.1
+    if: ${{ github.event.pull_request.merged == true }}
     steps:
       - uses: release-drafter/release-drafter@3782ccd
         env:


### PR DESCRIPTION
## Proposed Changes - 変更点の要約

自動リリース生成のトリガーを `main` ブランチに `push` されたときにしていたが、
これではワークフローでプルリクエストをマージさせた場合にイベントが発行されない。

よってプルリクエストのマージ時に変更した。

Fix #50

### Type of changes - 変更の種類

Please check the type of change your PR.
And write the type to as a prefix to the title of your PR ([Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)).

- [x] `fix`: A bug fix
- [ ] `feat`: A new feature
- [ ] appends `!` after the type or a commit has `BREAKING CHANGE:` in footer : Breaking change (feature or bug fix)
- [ ] `chore`: Build tool changes
- [ ] `docs`: Documentation only changes

---
[![actions/github-script](https://img.shields.io/badge/generated%20by-GitHub%20Sctipt%20v3.1.0-blue?logoColor=b3e5fc&logo=github-actions)](https://github.com/marketplace/actions/github-script)
