### PR TITLE
docs: fix about breaking changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,9 +11,10 @@ And write the type to as a prefix to the title of your PR ([Conventional Commits
 
 - [ ] `fix`: A bug fix
 - [ ] `feat`: A new feature
-- [ ] appends `!` after the type or a commit has `BREAKING CHANGE:` in footer : Breaking change (feature or bug fix)
 - [ ] `chore`: Build tool changes
 - [ ] `docs`: Documentation only changes
+
+⚠️ If there are breaking changes, appends **`!`** after the type or a commit has `BREAKING CHANGE:` in footer.
 
 ## What is the new behavior? (optional) - 新しい動作の補足説明
 


### PR DESCRIPTION
## Proposed Changes - 変更点の要約

`ISSUE_TEMPLATE` で `BREAKING CHANGE` の説明文を少し修正。

### Type of changes - 変更の種類

Please check the type of change your PR.
And write the type to as a prefix to the title of your PR ([Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)).

- [ ] `fix`: A bug fix
- [ ] `feat`: A new feature
- [ ] `chore`: Build tool changes
- [x] `docs`: Documentation only changes

⚠️ If there are breaking changes, appends **`!`** after the type or a commit has `BREAKING CHANGE:` in footer.

---
[![actions/github-script](https://img.shields.io/badge/generated%20by-GitHub%20Sctipt%20v3.1.0-blue?logoColor=b3e5fc&logo=github-actions)](https://github.com/marketplace/actions/github-script)
